### PR TITLE
Add trust proxy setting to express app configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ import { clubRouter } from './routes/clubRouter';
 const app = express()
 const PORT = 8000;
 
+// Add this line to trust proxy headers
+app.set('trust proxy', 1); // or true for all proxies
+
 app.use(express.json());
 app.use(cors());
 app.use('/api/v1/user', limiter);


### PR DESCRIPTION
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.
    at Object.xForwardedForHeader (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:187:13)
    at wrappedValidations.<computed> [as xForwardedForHeader] (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:398:22)
    at Object.keyGenerator (/opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:671:20)
    at /opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:724:32
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async /opt/render/project/src/node_modules/express-rate-limit/dist/index.cjs:704:5 {
  code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR',
  help: 'https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/'
} this one is done to avoid this error 