### PR TITLE
-Mohak main

### DIFF
--- a/prisma/migrations/20260615142424_queue/migration.sql
+++ b/prisma/migrations/20260615142424_queue/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "event" ADD COLUMN     "acceptanceBased" BOOLEAN DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "userEvents" ADD COLUMN     "approvalStatus" TEXT NOT NULL DEFAULT 'approved';
+
+-- CreateTable
+CREATE TABLE "eventQueue" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "eventQueue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "eventQueue_userId_eventId_key" ON "eventQueue"("userId", "eventId");
+
+-- AddForeignKey
+ALTER TABLE "eventQueue" ADD CONSTRAINT "eventQueue_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "eventQueue" ADD CONSTRAINT "eventQueue_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   event         event[]       @relation("EventCreator")
   eventAttended userEvents[]
   registrationAnswers RegistrationAnswer[]
+  eventQueue eventQueue[]
 }
 
 model clubs {
@@ -105,6 +106,7 @@ model event {
   endDate              String?
   eventHeaderImage     String?             @default("none")
   prizes               String              @default("no prizes given")
+  acceptanceBased      Boolean?             @default(false)
   EventMode            String              @default("Hybrid")
   EventType            String              @default("general")
   EventUrl             String?             @default("")
@@ -143,6 +145,7 @@ model event {
   attendees            userEvents[]
   customQuestions      EventCustomQuestion[]
   registrationAnswers  RegistrationAnswer[]
+  eventQueue           eventQueue[]
 }
 
 model eventAnnouncement {
@@ -183,6 +186,7 @@ model userEvents {
   paymentScreenshotUrl String?   @default("")
   paymentStatus        String    @default("CONFIRMED")
   paymentVerifiedAt    DateTime?
+  approvalStatus       String    @default("approved")
   event                event     @relation(fields: [eventId], references: [id])
   user                 User      @relation(fields: [userId], references: [id])
 
@@ -313,3 +317,16 @@ model RegistrationAnswer {
   @@unique([userId, eventId, questionId])
 }
 
+model eventQueue {
+  id       String   @id @default(uuid())
+  eventId   String
+  userId    String
+  status    String   @default("pending")
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  
+  event event @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  
+  @@unique([userId, eventId])
+}

--- a/src/controller/event.controller.ts
+++ b/src/controller/event.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import e, { Request, Response } from 'express';
 import { logger } from '../utils/logger';
 import { prisma } from '../db/db';
 import { EventSchema } from '../types/formtypes';
@@ -95,6 +95,7 @@ export const createEvent = async (req: Request, res: Response): Promise<void> =>
         applicationEndDate,
         coreTeamOnly,
         customQuestions,
+        acceptanceBased,
     } = req.body;
 
     const userId = req.id;
@@ -210,6 +211,7 @@ export const createEvent = async (req: Request, res: Response): Promise<void> =>
             qrCodeUrl: parsedData.data.paymentQRCode || parsedData.data.qrCodeUrl || null,
             maxParticipants: parsedData.data.maxParticipants ? parseInt(parsedData.data.maxParticipants.toString(), 10) : null,
             createdById: userId,
+            acceptanceBased: acceptanceBased ?? false,
         };
 
         if (customQuestions && Array.isArray(customQuestions) && customQuestions.length > 0) {
@@ -462,7 +464,8 @@ export const registerForEvent = async (req: Request, res: Response): Promise<voi
                 maxParticipants: true,
                 _count: {
                     select: { attendees: true }
-                }
+                },
+                acceptanceBased: true
             }
         });
 
@@ -534,6 +537,70 @@ export const registerForEvent = async (req: Request, res: Response): Promise<voi
             isPaid: event.isPaid
         });
 
+
+        // acceptance based event registration flow
+
+        if(event.acceptanceBased) {
+
+    
+        const response = await prisma.userEvents.create({
+            data: {
+                userId: userId,
+                eventId: eventId,
+                uniquePassId: generateUUID(),
+                paymentScreenshotUrl: paymentScreenshot || null,
+                paymentStatus: event.isPaid
+                    ? (paymentScreenshot ? 'CONFIRMED' : 'PENDING')
+                    : 'CONFIRMED',
+                approvalStatus: 'pending'
+            },
+            select: {
+                uniquePassId: true,
+                paymentStatus: true
+            }
+        });
+
+        if (customAnswers && Array.isArray(customAnswers) && customAnswers.length > 0) {
+         await prisma.registrationAnswer.createMany({
+                data: customAnswers.map((ans: any) => ({
+                    questionId: ans.questionId,
+                    userId: userId,
+                    eventId: eventId,
+                    answer: ans.answer
+                })),
+                skipDuplicates: true ,
+                
+            }, );
+        }
+
+
+        logger.info(`[${requestId}] User registered successfully`, {
+            userId,
+            eventId,
+            passId: response.uniquePassId,
+            paymentStatus: response.paymentStatus
+        });
+
+            const registred : boolean = await addToEventQueue(req , res, eventId); 
+            if(registred === false){
+                res.status(500).json({ msg: 'Failed to add registration to event queue' });
+                return;
+            } else {
+                logger.info(`[${requestId}] User added to event queue for acceptance-based event`, {
+                    userId,
+                    eventId
+                });
+                res.status(200).json({
+            msg: 'registered successfully , waiting for approval',
+            ForkedUpId: response.uniquePassId,
+            paymentStatus: response.paymentStatus,
+            requiresPaymentVerification: event.isPaid ,
+            approvalStatus: 'pending'
+                });
+            return;
+            }
+        }
+
         const response = await prisma.userEvents.create({
             data: {
                 userId: userId,
@@ -573,7 +640,8 @@ export const registerForEvent = async (req: Request, res: Response): Promise<voi
             msg: 'registered successfully',
             ForkedUpId: response.uniquePassId,
             paymentStatus: response.paymentStatus,
-            requiresPaymentVerification: event.isPaid
+            requiresPaymentVerification: event.isPaid,
+            approvalStatus : "confirmed"
         });
 
     } catch (error: any) {
@@ -2459,3 +2527,219 @@ export const deleteEvent = async (req: Request, res: Response): Promise<void> =>
         res.status(500).json({ msg: 'Internal server error' });
     }
 };
+
+
+// event queue for accepting or rejecting event registrations in bulk (for large events with many registrations)
+
+
+export const getEventQueue = async (req: Request, res: Response): Promise<void> => {
+
+    const userId = req.id;
+    const eventId = req.params.eventId as string;
+
+    if (!userId) {
+        res.status(401).json({ msg: 'Unauthorized' });
+        return;
+    }
+
+    try {
+        const user = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { email: true }
+        });
+
+        if (!user) {
+            res.status(404).json({ msg: 'User not found' });
+            return;
+        }
+
+        const event = await prisma.event.findUnique({
+            where: { id: eventId },
+            select: { clubId: true }
+        });
+
+        if (!event) {
+            res.status(404).json({ msg: 'Event not found' });
+            return;
+        }
+
+        const club = await prisma.clubs.findUnique({
+            where: {
+                id: event.clubId,
+            },
+            select: {
+                founderEmail: true,
+                coremember1: true,
+                coremember2: true,
+                coremember3: true
+            }
+        });
+
+        if (!club) {
+            res.status(404).json({ msg: 'Club not found' });
+            return;
+        }
+
+        if (club.founderEmail !== user.email && club.coremember1 !== user.email && club.coremember2 !== user.email && club.coremember3 !== user.email) {
+            res.status(403).json({ msg: 'Access denied. Only club heads or core members can view the event queue' });
+            return;
+        }
+
+        const queueEntries = await prisma.eventQueue.findMany({
+            where: { eventId },
+            orderBy: { createdAt: 'asc' }
+        });
+
+        const registrationAnswers = await prisma.registrationAnswer.findMany({
+            where : {
+                eventId : eventId,
+                userId: { in: queueEntries.map(q => q.userId) }
+            }, 
+            select : {
+                question : true,
+                answer : true,
+                userId : true
+            }
+        })
+
+        const registrationInfo = await prisma.userEvents.findMany({
+            where: {
+                eventId,
+                userId: { in: queueEntries.map(q => q.userId) }
+            },
+            select: {
+                userId: true,
+                uniquePassId: true,
+                paymentStatus: true,
+                paymentScreenshotUrl: true,
+                paymentVerifiedAt: true,
+                joinedAt: true,
+                user: {
+                    select: {
+                        name: true,
+                        email: true,
+                        collegeName: true
+                    }
+                }
+            }
+        });
+        
+        const queueEntriesWithDetails = queueEntries.map(entry => {
+            const registration = registrationInfo.find(r => r.userId === entry.userId);
+            return {
+                ...entry,
+                registration,
+                registrationAnswers: registrationAnswers.filter(a => a.userId === entry.userId) 
+            };
+        });
+
+        res.status(200).json({
+            msg: 'Event queue fetched successfully',
+            total: queueEntries.length,
+            queue: queueEntriesWithDetails
+        });
+
+    } catch (error: any) {
+        console.error(error);
+        res.status(500).json({ msg: 'Internal server error' });
+    }   
+
+}
+
+export const addToEventQueue = async (req: Request, res: Response, eventId: string): Promise<boolean> => { 
+
+    const requestId = generateRequestId();
+    const userId = req.id;
+
+    logger.info(`[${requestId}] Adding registration to event queue`, {
+        userId,
+        eventId
+    });
+    
+    if (!userId) {
+        res.status(401).json({ msg: 'Unauthorized' });
+        return false;
+    }
+
+    const addToEventQueue = await prisma.eventQueue.create({
+        data: {
+            eventId,
+            userId
+        }
+    });
+
+    logger.info(`[${requestId}] Registration added to event queue`, {
+        userId,
+        eventId,
+        queueEntryId: addToEventQueue.id
+    });
+
+    if (!addToEventQueue) {
+        logger.error(`[${requestId}] Failed to add registration to event queue`, {
+            userId,
+            eventId
+        });
+        res.status(500).json({ msg: 'Failed to add registration to event queue' });
+        return false;
+    } else {
+        logger.info(`[${requestId}] Registration successfully added to event queue`, {
+            userId,
+            eventId,
+            queueEntryId: addToEventQueue.id
+        });
+        return true;
+    }
+}
+
+export const acceptUserfromEventQueue = async (req: Request, res: Response): Promise<void> => { 
+    const requestId = generateRequestId();
+    const { userId , accepted } = req.body;
+    const eventId = req.params.eventId as string;
+
+    logger.info(`[${requestId}] Accepting user from event queue`, {
+        userId,
+        eventId
+    });
+
+    if (!userId) {
+        res.status(400).json({ msg: 'User ID is required' });
+        return;
+    }
+
+    try {
+        // Update registration status to approved
+        await prisma.userEvents.updateMany({
+            where: {
+                eventId,
+                userId
+            },
+            data: {
+                approvalStatus: accepted ? 'approved' : 'rejected'
+            }
+        });
+
+        // Remove from event queue
+        await prisma.eventQueue.deleteMany({
+            where: {
+                eventId,
+                userId
+            }
+        });
+
+        logger.info(`[${requestId}] User accepted from event queue`, {
+            userId,
+            eventId
+        });
+
+        res.status(200).json({ msg: 'User accepted successfully' });
+    } catch (error: any) {
+        console.error(error);
+        logger.error(`[${requestId}] Error accepting user from event queue`, {
+            error: error.message,
+            stack: error.stack,
+            userId,
+            eventId
+        });
+        res.status(500).json({ msg: 'Internal server error' });
+    }
+}

--- a/src/controller/user.controller.ts
+++ b/src/controller/user.controller.ts
@@ -643,11 +643,23 @@ export const isClubAdmin = async(req : Request, res: Response) : Promise<void> =
 
         const clubFounder = await prisma.clubs.findUnique({
             where : {
-                id : userDetails.clubId,
-                founderEmail : userDetails.email
+                id : userDetails.clubId
+            },
+            select : {
+                coremember1 : true,
+                coremember2 : true,
+                coremember3 : true,
+                founderEmail : true
             }
         })
 
+        if (!clubFounder || (clubFounder.founderEmail !== userDetails.email && clubFounder.coremember1 !== userDetails.email && clubFounder.coremember2 !== userDetails.email && clubFounder.coremember3 !== userDetails.email)) {
+            res.status(403).json({
+                msg : "you are not an admin"
+            })
+            return;
+        
+        }
         res.status(200).json({
             msg : "Fetched",
             founder : clubFounder ? 'true' : 'false'

--- a/src/routes/eventRouter.ts
+++ b/src/routes/eventRouter.ts
@@ -27,6 +27,8 @@ import {
   deleteEventSession,
   updateEvent,
   deleteEvent,
+  getEventQueue,
+  acceptUserfromEventQueue,
 } from '../controller/event.controller';
 import { 
   getAllannouncements, 
@@ -77,5 +79,9 @@ router.delete('/schedule/:eventId/session/:sessionId', AuthMiddleware, deleteEve
 // Edit & Delete Event
 router.put('/event/:id', AuthMiddleware, SpecificClubHeadAuthMiddleware, updateEvent);
 router.delete('/event/:id', AuthMiddleware, SpecificClubHeadAuthMiddleware, deleteEvent);
+
+// event Queue routes
+router.get('/eventQueue/:eventId', AuthMiddleware, AuthMiddleware, getEventQueue);
+router.put('/eventQueue/:eventId/approve', AuthMiddleware, acceptUserfromEventQueue);
 
 export const EventRouter = router;


### PR DESCRIPTION
This pull request introduces a new event registration queue system to support acceptance-based event registrations, along with related schema changes and controller logic. The main changes include new database tables and fields for tracking approval status, new controller methods for managing the event queue, and updates to the event registration flow to handle pending approvals.

**Database schema changes:**

* Added a new `eventQueue` table to manage pending event registrations, with unique constraints and foreign keys to `event` and `User` tables. [[1]](diffhunk://#diff-6ff0004234905bf1691e7388c6bfda797437d39bef5522945ae28a7e7c860391R1-R26) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR320-R332)
* Added `acceptanceBased` boolean field to the `event` model/table to indicate if an event requires approval for registration. [[1]](diffhunk://#diff-6ff0004234905bf1691e7388c6bfda797437d39bef5522945ae28a7e7c860391R1-R26) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR109)
* Added `approvalStatus` field to the `userEvents` model/table to track approval state (`approved`, `pending`, `rejected`). [[1]](diffhunk://#diff-6ff0004234905bf1691e7388c6bfda797437d39bef5522945ae28a7e7c860391R1-R26) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR189)
* Updated Prisma models to include new relations for `eventQueue` in `User` and `event`. [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR41) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR148)

**Event registration and queue logic:**

* Updated the event registration controller to support acceptance-based events: registrations for such events are added to `userEvents` with `approvalStatus: 'pending'` and placed in the `eventQueue`. The registration response reflects the pending status. [[1]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R540-R603) [[2]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9L576-R644)
* For non-acceptance-based events, registrations are immediately approved as before.

**Event queue management endpoints:**

* Added new controller methods:
  - `getEventQueue`: Allows club admins to view the event queue with registration details and answers for a given event.
  - `addToEventQueue`: Adds a user registration to the event queue (used internally).
  - [`acceptUserfromEventQueue`](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R2530-R2745): Allows admins to approve or reject a user's registration, updating status and removing from the queue.
* Added corresponding routes to `eventRouter.ts` for queue management. [[1]](diffhunk://#diff-bb47766579f12067530dc25627d1ba9fcd52a1bf5b83b13a2030ffbc3fc43036R30-R31) [[2]](diffhunk://#diff-bb47766579f12067530dc25627d1ba9fcd52a1bf5b83b13a2030ffbc3fc43036R83-R86)

**Authorization improvements:**

* Improved admin checks to ensure only club founders or core members can access or manage the event queue. [[1]](diffhunk://#diff-7bafc2ae9961d1ccd1530f259e0b94568608e812bd34a1e3ca2cceddd225c177L646-R662) [[2]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R2530-R2745)

**Other minor changes:**

* Passed `acceptanceBased` through event creation logic and included it in event queries. [[1]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R98) [[2]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R214) [[3]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9L465-R468)

**References:**  
[[1]](diffhunk://#diff-6ff0004234905bf1691e7388c6bfda797437d39bef5522945ae28a7e7c860391R1-R26) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR41) [[3]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR109) [[4]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR148) [[5]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR189) [[6]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR320-R332) [[7]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R98) [[8]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R214) [[9]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9L465-R468) [[10]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R540-R603) [[11]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9L576-R644) [[12]](diffhunk://#diff-64c913f753f394e9a4359b7923e935d827bfb09960be599f07516afef187cfa9R2530-R2745) [[13]](diffhunk://#diff-7bafc2ae9961d1ccd1530f259e0b94568608e812bd34a1e3ca2cceddd225c177L646-R662) [[14]](diffhunk://#diff-bb47766579f12067530dc25627d1ba9fcd52a1bf5b83b13a2030ffbc3fc43036R30-R31) [[15]](diffhunk://#diff-bb47766579f12067530dc25627d1ba9fcd52a1bf5b83b13a2030ffbc3fc43036R83-R86)